### PR TITLE
ScoreDefs and settings module improvements

### DIFF
--- a/common/settings.py
+++ b/common/settings.py
@@ -18,7 +18,7 @@ class ConfigParseError(Exception):
 
 # "lenient" is a temporary solution to make debugging easier.
 # Long-term solution: only import settings that are needed at the locations they are used --> need to turn them into lamdbas
-def _parse(entry, f=lambda x : x, default="", lenient=True):
+def _parse(entry, f=lambda x : x, default="", lenient=False):
     try:
         entry_type = type(default)
         return entry_type(f(_config[entry])) # Use constructor of entry type

--- a/common/settings.py
+++ b/common/settings.py
@@ -6,26 +6,47 @@ from pathlib import Path
 '''
 Contains the required settings for the python scripts from the yaml along with some pre-processing
 '''
+_config = {}
+def reload():
+    with open("../settings.yaml", "r") as file:
+        global _config
+        _config = yaml.safe_load(file.read())
+reload()
 
-with open("../settings.yaml", "r") as file:
-    config = yaml.safe_load(file.read())
+class ConfigParseError(Exception):
+    pass
 
-base_sheet_path = Path(config["base_sheet_path"]) # Can just use the "/" operator with Path
-mongo_address = re.search('[a-zA-Z]+:[0-9]+', config["mongo_server"]).group(0).split(":") # [ip, port]
-rabbitmq_address = config["rabbitmq_address"].split(":") # [ip, port] 
-score_queue_name = config["mq_score_queue"]
-sheet_queue_name = config["mq_sheet_queue"]
-new_item_queue_name = config["mq_new_item_queue"]
-sheet_collection_name = config["mongo_sheet_collection"]
-score_collection_name = config["mongo_score_collection"]
-slice_collection_name = config["mongo_slice_collection"]
-aggregated_result_collection_name = config["mongo_aggregated_result_collection"]
-score_rebuilder_queue_name = config["mq_score_rebuilder_queue"]
-github_user = config["github_user"]
-github_token = config["github_token"]
-github_organization_name = config["github_organization"]
-github_queue_name = config["mq_github_queue"]
-github_init_queue_name = config["mq_github_init_queue"]
-github_branch_name = config["github_branch"]
-github_commit_count_before_push = int(config["github_commit_count_before_push"])
-task_collection_name = config["mongo_task_collection"]
+# "lenient" is a temporary solution to make debugging easier.
+# Long-term solution: only import settings that are needed at the locations they are used --> need to turn them into lamdbas
+def _parse(entry, f=lambda x : x, default="", lenient=True):
+    try:
+        entry_type = type(default)
+        return entry_type(f(_config[entry])) # Use constructor of entry type
+    except Exception as e:
+        if lenient:
+            print(f"WARNING: Could not parse config entry '{entry}', ensure it has the correct format, continuing with default value: {default}")
+        else:
+            raise ConfigParseError(f"ERROR: Could not parse config entry '{entry}', ensure it has the correct format.", e)
+    return default
+
+
+
+base_sheet_path                     = _parse("base_sheet_path", default=Path("sheets"))
+mongo_address                       = _parse("mongo_server", f=lambda x : re.search('[a-zA-Z]+:[0-9]+', x).group(0).split(":")) 
+rabbitmq_address                    = _parse("rabbitmq_address", f=lambda x: x.split(":")) # [ip, port] 
+score_queue_name                    = _parse("mq_score_queue")
+sheet_queue_name                    = _parse("mq_sheet_queue")
+new_item_queue_name                 = _parse("mq_new_item_queue")
+sheet_collection_name               = _parse("mongo_sheet_collection")
+score_collection_name               = _parse("mongo_score_collection")
+slice_collection_name               = _parse("mongo_slice_collection")
+aggregated_result_collection_name   = _parse("mongo_aggregated_result_collection")
+score_rebuilder_queue_name          = _parse("mq_score_rebuilder_queue")
+github_user                         = _parse("github_user")
+github_token                        = _parse("github_token")
+github_organization_name            = _parse("github_organization")
+github_queue_name                   = _parse("mq_github_queue")
+github_init_queue_name              = _parse("mq_github_init_queue")
+github_branch_name                  = _parse("github_branch")
+github_commit_count_before_push     = _parse("github_commit_count_before_push", default=5)
+task_collection_name                = _parse("mongo_task_collection")

--- a/common/settings.py
+++ b/common/settings.py
@@ -26,7 +26,7 @@ def _parse(entry, f=lambda x : x, default="", lenient=False):
         if lenient:
             print(f"WARNING: Could not parse config entry '{entry}', ensure it has the correct format, continuing with default value: {default}")
         else:
-            raise ConfigParseError(f"ERROR: Could not parse config entry '{entry}', ensure it has the correct format.", e)
+            raise ConfigParseError(f"ERROR: Could not parse config entry '{entry}', ensure it has the correct format (set 'lenient' to `True` to avoid this).", e) from e
     return default
 
 

--- a/slicer/slicer.py
+++ b/slicer/slicer.py
@@ -101,7 +101,7 @@ class Measure(namedtuple("Measure", ["ulc", "lrc", "width", "height", "index", "
 
 Line = namedtuple("Line", ["measures", "start", "index"])
 Page = namedtuple("Page", ["lines", "start", "index", "image_name"])
-ScoreDef = namedtuple("ScoreDef", ["location", "xml"]) # "location" is the index of the first measure after it (in other words, first measure where it takes effect)
+ScoreDef = namedtuple("ScoreDef", ["index", "location", "xml"]) # "location" is the index of the first measure after it (in other words, first measure where it takes effect)
 
 class NoScoreDefException(Exception):
     pass
@@ -146,7 +146,7 @@ class Score:
             score_def_xml_node = [x for x in score_node.childNodes if x.nodeType == xml.Node.ELEMENT_NODE and x.tagName == 'scoreDef'][0]
         except IndexError as e:
             raise NoScoreDefException("ERROR: The MEI does not contain a global score def!") from e
-        self.score_def = ScoreDef(0, score_def_xml_node.toxml())
+        self.score_defs.append(ScoreDef(0, 0, score_def_xml_node.toxml()))
 
         line = []
         page = []
@@ -175,7 +175,7 @@ class Score:
                 self.measures.append(score_measure)
                 line.append(score_measure)
             if entry.tagName == "scoreDef":
-                self.score_defs.append(ScoreDef(len(self.measures), entry.toxml()))
+                self.score_defs.append(ScoreDef(len(self.score_defs), len(self.measures), entry.toxml()))
 
 
     def get_page_image(self, page_index):
@@ -252,8 +252,7 @@ class Score:
         score_dict = {
         "name" : self.name,
         "measures": [dict(measure.to_db_dict()) for measure in self.measures],
-        "score_defs" : [dict(self.score_def._asdict()) for score_def in self.score_defs],
-        "main_score_def": dict(self.score_def._asdict())
+        "score_defs" : [dict(score_def._asdict()) for score_def in self.score_defs]
         }
 
         return score_dict

--- a/slicer/slicer_terminal.py
+++ b/slicer/slicer_terminal.py
@@ -3,6 +3,7 @@ import pika
 import pathlib
 import os
 import sys
+import pprint
 
 sys.path.append("..")
 import common.settings as settings
@@ -16,6 +17,7 @@ parser.add_argument('path', type=str, help='Path to the main directory of the sc
 parser.add_argument('-o','--output', type=str, help='Output path, if not given it will create a folder called "slices" at the same location as the .mei file.')
 parser.add_argument('-s','--store_in_db', action="store_true", help="Store whatever slices are being created in mongo db, uses address and collection names from config.")
 parser.add_argument('-q','--message_queue', type=str, help="Create a message queue entry, uses address and queue names from config.")
+parser.add_argument('-d', '--debug_data', action="store_true", help="Only print the created data structures to the console for debugging and then exit.")
 
 group = parser.add_mutually_exclusive_group()
 group.add_argument('-a','--all', nargs='?', const=True, type=bool, help='Create all single measures, double measures, and lines.')
@@ -32,6 +34,11 @@ measure_path = f"{out_path}measures{os.path.sep}"
 line_path = f"{out_path}lines{os.path.sep}"
 double_measure_path = f"{out_path}double_measures{os.path.sep}"
 
+if args.debug_data:
+    pp = pprint.PrettyPrinter(indent=4)
+    pp.pprint(score.to_db_dict())
+    sys.exit()
+
 if args.output:
     out_path = output
 
@@ -40,6 +47,7 @@ def save_slice(score_slice, path):
     stored_slices.append(score_slice)
     pathlib.Path(path).mkdir(parents=True, exist_ok=True)
     score_slice.get_image().save(path + score_slice.get_name())
+
 
 if args.all or args.measure == -1:
     for score_slice in score.get_measure_slices():


### PR DESCRIPTION
Adds a couple of things:
- Overhauls the settings module to use a parse function, along with a `lenient` flag that can be set to make it continue anyway on parse errors. This is a short-term solution for quick debugging.
- Added data printing feature to the slicer's terminal interface for debugging
- The main `scoreDef` and any subsequent `scoreDef`s now get stored, containing: 
  - Index of the `scoreDef`, to preserve their sequential order
  - Location of the first measure that is affected by the `scoreDef` (is a measure index)
  - The XML that was in the `scoreDef`
- Some error/exception handling for some of the new features