### PR TITLE
Unique score IDs for scores, and some other fixes

### DIFF
--- a/github/github_common.py
+++ b/github/github_common.py
@@ -14,7 +14,10 @@ def commit(repo, message, branch="master"):
     oid = repo.create_commit(f"refs/heads/{branch}", signature, signature, message, tree, [repo.head.peel().hex])
     
 
-def push(repo, branch="master"):
+def push(repo, branch="master", force=False):
+    f = ''
+    if force:
+        f = '+'
     remote = repo.remotes["origin"]
     remote.credentials = pygit2.UserPass(cfg.github_user, cfg.github_token)
-    remote.push([f"refs/heads/{branch}"], callbacks=pygit2.RemoteCallbacks(credentials=remote.credentials))
+    remote.push([f"{f}refs/heads/{branch}"], callbacks=pygit2.RemoteCallbacks(credentials=remote.credentials))

--- a/task_scheduler/task_scheduler_new.py
+++ b/task_scheduler/task_scheduler_new.py
@@ -158,6 +158,8 @@ def take_action_on_status(channel, method, properties, body):
                                                         check_stage_completion
                                                     ],
         ("github_update", "complete"):              [
+                                                    ],
+        ("github_update", "failed"):                [
                                                     ]
     }[(module, status)]
 
@@ -524,17 +526,19 @@ def initialize_stage(message, channel):
     message_history.clear() # TODO: It's probably important to do this per score as well...
 
     # Send message for task types to CE
-    for task_type in task_types:
-        send_message(
-            {
-                "action": 'task type created',
-                "score_name": score_name,
-                "name": task_type,
-                "title": task_type
-            },
-            cfg.mq_ce_communicator,
-            channel
-        )
+    for task_type_name in task_types:
+        task_type = task_types[task_type_name]
+        if task_type in stage.task_types:
+            send_message(
+                {
+                    "action": 'task type created',
+                    "score_name": score_name,
+                    "name": task_type_name,
+                    "title": task_type.nice_name
+                },
+                cfg.mq_ce_communicator,
+                channel
+            )
 
     print(f"Initializing stage {stage.order} for score {score_name}")
     create_tasks_and_batches_for_stage(stage, score_name)

--- a/task_scheduler/task_type.py
+++ b/task_scheduler/task_type.py
@@ -17,6 +17,7 @@ DONE_STEP = "done"
 class TaskType():
     def __init__(self, name, body, db):
         self.name = name
+        self.nice_name = body["name"]
         self.get_task_priority = getattr(priority_functions, body["prioritization"])
         self.steps = OrderedDict({x["name"]: x for x in body["steps"]})
         self.slice_type = body["slice_type"]

--- a/task_scheduler/tasks/0/clef_recognition.yaml
+++ b/task_scheduler/tasks/0/clef_recognition.yaml
@@ -1,3 +1,5 @@
+name: "Clef Recognition"          # "Nice" name for this task type
+
 steps:                            # Ordered steps for this task, each step has a 'name' and 'requirements'
 - name: edit
   requirements : []               # List of UI requirements for this task step

--- a/task_scheduler/tasks/1/time_recognition.yaml
+++ b/task_scheduler/tasks/1/time_recognition.yaml
@@ -1,3 +1,5 @@
+name: "Time Recognition"          # "Nice" name for this task type
+
 steps:                            # Ordered steps for this task, each step has a 'name' and 'requirements'
 - name: edit
   requirements : []               # List of UI requirements for this task step

--- a/task_scheduler/tasks/2/key_recognition.yaml
+++ b/task_scheduler/tasks/2/key_recognition.yaml
@@ -1,3 +1,5 @@
+name: "Key Recognition"           # "Nice" name for this task type
+
 steps:                            # Ordered steps for this task, each step has a 'name' and 'requirements'
 - name: edit
   requirements : []               # List of UI requirements for this task step


### PR DESCRIPTION
This PR implements the following:
- Scores obtained from CE now have a unique ID, based on their digital-document ID
- When running multiple campaigns, the github modules started failing due to delay in the API, so some (band-aid-ish) robustness was added. This can be cleaned up a bit later.
- Task scheduler was serving all task types to the CE every stage per score. Now it will only serve task types for the current stage, so there will be no more duplicates.
- Tasks now have a "nice name", which could be used as display name in the CE